### PR TITLE
Fix usergroup handle bug

### DIFF
--- a/doorbot/app.py
+++ b/doorbot/app.py
@@ -351,7 +351,7 @@ async def check_user_authed(user_id):
 
             if config.admin_usergroup_id is None:
                 raise Exception(
-                    f"Could not find usergroup '{config.admin_usergroup_name}'")
+                    f"Could not find usergroup '{config.admin_usergroup_handle}'")
 
         # Get authorised users
         response = await app.client.usergroups_users_list(usergroup=config.admin_usergroup_id)


### PR DESCRIPTION
## Summary
- fix typo when logging missing Slack user group

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pigpio')*

------
https://chatgpt.com/codex/tasks/task_e_6840313e513083258764a23483eaf6c8