### PR TITLE
Fix docstring typo

### DIFF
--- a/doorbot/interfaces/user_manager.py
+++ b/doorbot/interfaces/user_manager.py
@@ -1,5 +1,5 @@
 """
-Manaage downloading, storing and authorising keys and sounds for each user.
+Manage downloading, storing and authorising keys and sounds for each user.
 """
 
 import os


### PR DESCRIPTION
## Summary
- fix user manager docstring comment

## Testing
- `pytest doorbot/tests/user_manager_test.py -q` *(fails: token/key_to_play arguments required)*

------
https://chatgpt.com/codex/tasks/task_e_684034fc2a7c83259b2bee16180e23da